### PR TITLE
Fix: Ensure master CSV header always includes all standard elements

### DIFF
--- a/src/main/java/com/medals/libsdatagenerator/service/LIBSDataService.java
+++ b/src/main/java/com/medals/libsdatagenerator/service/LIBSDataService.java
@@ -20,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays; // Added import
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -253,7 +254,7 @@ public class LIBSDataService {
         // Keeping track of all wavelength across all comps:
         Set<Double> allWavelengths = new TreeSet<>();
 
-        // all Element symbols across all comps:
+        // all Element symbols across all comps (can be kept if used elsewhere, or removed if only for header):
         Set<String> allElementSymbols = new TreeSet<>();
 
         // Store for each composition's *string ID* -> (wave -> intensity)
@@ -343,8 +344,9 @@ public class LIBSDataService {
         // Convert sets to sorted lists
         List<Double> sortedWaves = new ArrayList<>(allWavelengths);
         Collections.sort(sortedWaves); // TreeSet is already sorted, but okay to be explicit
-        List<String> sortedSymbols = new ArrayList<>(allElementSymbols);
-        Collections.sort(sortedSymbols);
+        // Use STD_ELEMENT_LIST for header and row structure for elements
+        List<String> sortedSymbols = new ArrayList<>(Arrays.asList(LIBSDataGenConstants.STD_ELEMENT_LIST));
+        Collections.sort(sortedSymbols); // Ensure canonical order
 
         // Build header
         List<String> header = new ArrayList<>();
@@ -354,7 +356,7 @@ public class LIBSDataService {
             header.add(String.valueOf(w));
         }
         // Add element columns
-        for (String sym : sortedSymbols) {
+        for (String sym : sortedSymbols) { // Now uses STD_ELEMENT_LIST
             header.add(sym);
         }
 
@@ -371,6 +373,7 @@ public class LIBSDataService {
             // Each composition => one row
             for (String compId : compWaveIntensity.keySet()) {
                 Map<Double, Double> waveMap = compWaveIntensity.get(compId);
+                // Get the specific element map for the row
                 Map<String, Double> elemMap = compElementPcts.get(compId);
 
                 List<String> row = new ArrayList<>();
@@ -382,8 +385,9 @@ public class LIBSDataService {
                     row.add(String.valueOf(intensity));
                 }
 
-                // For each element symbol, add the percentage (or 0.0 if missing)
-                for (String sym : sortedSymbols) {
+                // For each element symbol FROM STD_ELEMENT_LIST, add the percentage
+                for (String sym : sortedSymbols) { // Iterates using STD_ELEMENT_LIST
+                    // Correctly gets 0 if element not in this specific compId's map
                     Double pct = elemMap.getOrDefault(sym, 0.0);
                     row.add(String.valueOf(pct));
                 }

--- a/src/main/java/com/medals/libsdatagenerator/util/CSVUtils.java
+++ b/src/main/java/com/medals/libsdatagenerator/util/CSVUtils.java
@@ -60,15 +60,25 @@ public class CSVUtils {
         if (!append && Files.exists(csvPath)) {
             backupCsv(csvPath);
         }
+
         BufferedWriter writer;
         if (append) {
+            boolean fileExists = Files.exists(csvPath);
+            long fileSize = fileExists ? Files.size(csvPath) : 0;
+            boolean fileExistsAndIsNotEmpty = fileExists && fileSize > 0;
+            
             writer = Files.newBufferedWriter(csvPath,
                     StandardOpenOption.APPEND,
                     StandardOpenOption.CREATE);
-            // Use DEFAULT format without writing headers again.
-            return new CSVPrinter(writer, CSVFormat.DEFAULT);
-        } else {
-            // Create new file (truncate if exists) and write header.
+
+            if (fileExistsAndIsNotEmpty) {
+                // File exists and has content, so append without writing a new header
+                return new CSVPrinter(writer, CSVFormat.DEFAULT);
+            } else {
+                // File is new or was empty, so write the header
+                return new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(header));
+            }
+        } else { // !append
             writer = Files.newBufferedWriter(csvPath,
                     StandardOpenOption.CREATE,
                     StandardOpenOption.TRUNCATE_EXISTING);


### PR DESCRIPTION
The master_dataset.csv was previously generated with a header based only on the elements present in the initial batch of compositions. If this batch did not include all elements from LIBSDataGenConstants.STD_ELEMENT_LIST, the header would be incomplete.

Subsequent appends, which correctly processed data for all standard elements (filling missing ones with zero), would then have more data columns than header columns. This led to misaligned data and effective null values when reading the CSV.

This commit addresses the issue by:
1. Modifying LIBSDataService.java (generateDataset method) to always use LIBSDataGenConstants.STD_ELEMENT_LIST for defining the element columns in the CSV header and for structuring data rows. This ensures 0.0 is written for standard elements not present in a specific composition.
2. Modifying CSVUtils.java (getCsvPrinter method) to ensure that the header is written to the CSV file if it's new or empty, even when opened in append mode. This guarantees that the first write to a fresh CSV establishes the correct, complete header.

The conceptual test plan involves:
- Creating a master_dataset.csv with an initial batch missing some standard elements. Verify the CSV header contains all standard elements.
- Appending a new batch with different standard elements. Verify data aligns correctly under the full header.