### PR TITLE
Fix: Untrack test_elements.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Build/logs/
 Build/lib/
 .idea/
 target/
+src/test/resources/test_elements.properties


### PR DESCRIPTION
I've removed src/test/resources/test_elements.properties from git tracking. This file is generated during your local builds and shouldn't be part of the repository, as it causes unnecessary uncommitted changes.

I've also added the file path to .gitignore to prevent accidental re-tracking.