### PR TITLE
feat: Implement steel series processing via CLI

### DIFF
--- a/TestCLI.java
+++ b/TestCLI.java
@@ -1,0 +1,52 @@
+import com.medals.libsdatagenerator.util.CommonUtils;
+import org.apache.commons.cli.CommandLine;
+
+public class TestCLI {
+    public static void main(String[] args) {
+        CommonUtils commonUtils = new CommonUtils();
+        String[][] testCases = {
+            {"-c", "some_guid"}, // should pass
+            {"-s"}, // should pass
+            {"-s", "some_series_key"}, // should pass
+            {}, // should fail, neither -c nor -s
+            {"-c", "some_guid", "-s", "some_series_key"}, // should fail, both -c and -s
+            {"-c", "some_guid", "-s"} // should fail, both -c and -s
+        };
+
+        String[] descriptions = {
+            "Test Case 1: -c some_guid (should pass)",
+            "Test Case 2: -s (should pass)",
+            "Test Case 3: -s some_series_key (should pass)",
+            "Test Case 4: (empty args) (should fail)",
+            "Test Case 5: -c some_guid -s some_series_key (should fail)",
+            "Test Case 6: -c some_guid -s (should fail)"
+        };
+
+        boolean[] expectedResults = {
+            true, // pass
+            true, // pass
+            true, // pass
+            false, // fail
+            false, // fail
+            false  // fail
+        };
+
+        System.out.println("Starting CLI argument handler tests...");
+
+        for (int i = 0; i < testCases.length; i++) {
+            System.out.println("\n" + descriptions[i]);
+            String[] currentArgs = testCases[i];
+            CommandLine cmd = commonUtils.getTerminalArgHandler(currentArgs);
+            boolean result = (cmd != null);
+
+            if (result == expectedResults[i]) {
+                System.out.println("Result: PASS");
+            } else {
+                System.out.println("Result: FAIL");
+                System.out.println("  Expected: " + (expectedResults[i] ? "CommandLine object" : "null"));
+                System.out.println("  Actual:   " + (result ? "CommandLine object" : "null"));
+            }
+        }
+        System.out.println("\nCLI argument handler tests finished.");
+    }
+}

--- a/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataController.java
+++ b/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataController.java
@@ -7,9 +7,13 @@ import com.medals.libsdatagenerator.util.CommonUtils;
 import org.apache.commons.cli.CommandLine;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.net.HttpURLConnection; // Added for HTTP status codes
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import com.medals.libsdatagenerator.service.SeriesStatistics;
 
 /**
  * @author Siddharth Prince | 16/12/24 18:22
@@ -17,41 +21,279 @@ import java.util.regex.Pattern;
 
 public class LIBSDataController {
     private static Logger logger = Logger.getLogger(LIBSDataController.class.getName());
+    private static final Pattern MATWEB_GUID_PATTERN = Pattern.compile(LIBSDataGenConstants.MATWEB_GUID_REGEX);
+
+    private static class SeriesData {
+        String seriesKey;
+        List<String> individualMaterialGuids;
+        String overviewGuid;
+
+        SeriesData(String seriesKey, List<String> individualMaterialGuids, String overviewGuid) {
+            this.seriesKey = seriesKey;
+            this.individualMaterialGuids = individualMaterialGuids;
+            this.overviewGuid = overviewGuid;
+        }
+    }
+
+    private static SeriesData parseSeriesEntry(String key, String entryString, Pattern guidPattern) {
+        if (entryString == null || entryString.trim().isEmpty()) {
+            logger.warning("Empty entry string for series key: " + key + ". Skipping.");
+            return null;
+        }
+
+        List<String> individualGuids = new ArrayList<>();
+        String overviewGuid = null;
+        boolean hasValidGuid = false;
+
+        String[] parts = entryString.split(",");
+        for (String part : parts) {
+            String trimmedPart = part.trim();
+            if (trimmedPart.isEmpty()) {
+                continue;
+            }
+
+            if (trimmedPart.startsWith("og-")) {
+                String potentialOgGuid = trimmedPart.substring(3);
+                if (!potentialOgGuid.isEmpty()) {
+                    if (guidPattern.matcher(potentialOgGuid).matches()) {
+                        if (overviewGuid == null) {
+                            overviewGuid = potentialOgGuid;
+                            hasValidGuid = true; // An overview GUID is a valid GUID for the entry
+                        } else {
+                            logger.warning("Multiple overview GUIDs found for series: " + key +
+                                           ". Using first one ('" + overviewGuid + "'), ignoring '" + potentialOgGuid + "'.");
+                        }
+                    } else {
+                        logger.warning("Invalid overview GUID format in series: " + key +
+                                       ". Value: '" + potentialOgGuid + "'. Skipping this overview GUID part.");
+                    }
+                } else {
+                     logger.warning("Empty overview GUID (after 'og-') in series: " + key +
+                                   ". Part: '" + trimmedPart + "'. Skipping.");
+                }
+            } else { // Individual material GUID
+                if (guidPattern.matcher(trimmedPart).matches()) {
+                    individualGuids.add(trimmedPart);
+                    hasValidGuid = true; // An individual GUID is a valid GUID for the entry
+                } else {
+                    logger.warning("Invalid individual material GUID format in series: " + key +
+                                   ". Value: '" + trimmedPart + "'. Skipping this GUID.");
+                }
+            }
+        }
+
+        // Only return a SeriesData object if there's at least one valid GUID (overview or individual)
+        // and an overview GUID is present, as per current logic focusing on overview GUIDs for processing.
+        // This condition might be adjusted if individualMaterialGuids become primary.
+        if (overviewGuid != null) { // Modified this condition to primarily care about overviewGuid for now
+            return new SeriesData(key, individualGuids, overviewGuid);
+        } else if (hasValidGuid) { // Entry has individual guids but no overview_guid
+            logger.warning("Series entry for key '" + key + "' has individual GUIDs but no valid overview GUID. Skipping processing for this series as overview GUID is currently required.");
+            return null;
+        }
+        else {
+            logger.warning("No valid GUIDs (overview or individual) found for series key: " + key + " in entry: '" + entryString + "'. Skipping.");
+            return null;
+        }
+    }
 
     public static void main(String[] args) {
         logger.info("Starting LIBS Data Curator...");
 
         LIBSDataService libsDataService = LIBSDataService.getInstance();
+        CommonUtils commonUtils = new CommonUtils(); // Instance for various utilities
 
         try {
             // Check if the NIST LIBS portal is reachable
             if (libsDataService.isNISTLIBSReachable()) {
                 logger.info("Initialising LIBS Data extraction...");
 
-                CommandLine cmd = new CommonUtils().getTerminalArgHandler(args);
+                CommandLine cmd = commonUtils.getTerminalArgHandler(args);
 
-                if (cmd != null) {
-                    // Parsing user inputs
+                if (cmd == null) {
+                    logger.severe("Failed to parse command line arguments. Aborting.");
+                    return;
+                }
+
+                // Common parameters
+                String minWavelength = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MIN_WAVELENGTH_SHORT, "200");
+                String maxWavelength = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MAX_WAVELENGTH_SHORT, "800");
+                String csvDirPath = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_OUTPUT_PATH_SHORT, CommonUtils.DATA_PATH);
+                boolean appendMode = !cmd.hasOption(LIBSDataGenConstants.CMD_OPT_NO_APPEND_MODE_SHORT);
+                boolean forceFetch = cmd.hasOption(LIBSDataGenConstants.CMD_OPT_FORCE_FETCH_SHORT);
+
+                // Logic for -s (series) option
+                if (cmd.hasOption(LIBSDataGenConstants.CMD_OPT_SERIES_SHORT)) {
+                    logger.info("Processing with -s (series) option.");
+
+                    // Load series properties only if -s option is used
+                    Properties seriesProperties = commonUtils.readProperties(LIBSDataGenConstants.STEEL_SERIES_CATALOG_PATH);
+                    if (seriesProperties.isEmpty()) {
+                        logger.warning("steel_series_catalog.properties file is empty or not found. Cannot process series option.");
+                        // Subsequent checks for processedSeriesList.isEmpty() or its contents will handle the abort if no valid series are found.
+                    }
+
+                    ArrayList<SeriesData> processedSeriesList = new ArrayList<>();
+                    String seriesKeyValueInput = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_SERIES_SHORT);
+
+                    if (seriesKeyValueInput != null) { // User provided one or more series keys
+                        logger.info("Processing series key(s): " + seriesKeyValueInput);
+                        String[] seriesKeys = seriesKeyValueInput.split(",");
+                        for (String singleKey : seriesKeys) {
+                            String trimmedKey = singleKey.trim();
+                            if (trimmedKey.isEmpty()) {
+                                logger.warning("Empty series key found in comma-separated list. Skipping.");
+                                continue;
+                            }
+                            if (!seriesProperties.isEmpty() && seriesProperties.containsKey(trimmedKey)) {
+                                String seriesEntry = seriesProperties.getProperty(trimmedKey);
+                                SeriesData sData = parseSeriesEntry(trimmedKey, seriesEntry, MATWEB_GUID_PATTERN);
+                                if (sData != null) {
+                                    processedSeriesList.add(sData);
+                                }
+                            } else if (seriesProperties.isEmpty()) {
+                                logger.warning("Cannot look up series key: " + trimmedKey + " because steel_series_catalog.properties is empty or not found.");
+                            } else {
+                                logger.warning("Series key: " + trimmedKey + " not found in steel_series_catalog.properties. Skipping.");
+                            }
+                        }
+                    } else { // Process all series from the properties file (-s without a value)
+                        logger.info("Processing all series from steel_series_catalog.properties.");
+                        if (!seriesProperties.isEmpty()) {
+                            for (String key : seriesProperties.stringPropertyNames()) {
+                                String seriesEntry = seriesProperties.getProperty(key);
+                                SeriesData sData = parseSeriesEntry(key, seriesEntry, MATWEB_GUID_PATTERN);
+                                if (sData != null) {
+                                    processedSeriesList.add(sData);
+                                }
+                            }
+                        } else {
+                            logger.warning("Cannot process all series because steel_series_catalog.properties is empty or not found.");
+                        }
+                    }
+
+                    // Check if any series contain individual material GUIDs to process
+                    boolean hasIndividualGuidsToProcess = false;
+                    for (SeriesData sd : processedSeriesList) {
+                        if (sd.individualMaterialGuids != null && !sd.individualMaterialGuids.isEmpty()) {
+                            hasIndividualGuidsToProcess = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasIndividualGuidsToProcess) {
+                        logger.severe("No individual material GUIDs found within the specified series entries to process. Aborting.");
+                        return;
+                    }
+                    logger.info("Found " + processedSeriesList.size() + " series entries with potential materials to process.");
+
+                    MatwebDataService matwebService = MatwebDataService.getInstance(); // Initialize MatwebDataService
+
+                    for (SeriesData currentSeriesData : processedSeriesList) {
+                        String seriesKey = currentSeriesData.seriesKey;
+                        List<String> individualMaterialGuids = currentSeriesData.individualMaterialGuids;
+                        String seriesOverviewGuid = currentSeriesData.overviewGuid; // This is the OG for the current series
+
+                        if (individualMaterialGuids.isEmpty()) {
+                            logger.info("No individual material GUIDs found for series: " + seriesKey + ". Skipping this series entry.");
+                            continue;
+                        }
+
+                        logger.info("Processing series: " + seriesKey + " with " + individualMaterialGuids.size() + " individual material(s). Overview GUID for variations: " + (seriesOverviewGuid != null ? seriesOverviewGuid : "N/A"));
+
+                        for (String individualGuid : individualMaterialGuids) {
+                            logger.info("Processing material GUID: " + individualGuid + " from series: " + seriesKey);
+
+                            String[] compositionArray = matwebService.getMaterialComposition(individualGuid);
+
+                            if (compositionArray == null || compositionArray.length == 0) {
+                                logger.warning("Failed to fetch composition (null or empty array) for material GUID: " + individualGuid + ". Skipping this material.");
+                                continue;
+                            }
+                            if (compositionArray.length == 1) {
+                                if (compositionArray[0].equals(String.valueOf(HttpURLConnection.HTTP_NOT_FOUND))) {
+                                    logger.warning("Material GUID: " + individualGuid + " not found (404) on MatWeb. Skipping this material.");
+                                    continue;
+                                }
+                                if (compositionArray[0].equals(String.valueOf(HttpURLConnection.HTTP_INTERNAL_ERROR))) {
+                                    logger.warning("MatWeb internal server error (500) for material GUID: " + individualGuid + ". Skipping this material.");
+                                    continue;
+                                }
+                            }
+
+                            ArrayList<Element> baseElements = libsDataService.generateElementsList(compositionArray);
+                            if (baseElements == null || baseElements.isEmpty()) {
+                                logger.warning("Failed to generate elements for material GUID: " + individualGuid + " from composition: " + String.join(",", compositionArray) + ". Skipping this material.");
+                                continue;
+                            }
+                            logger.info("Base elements for " + individualGuid + ": " + commonUtils.buildCompositionString(baseElements));
+
+                            if (cmd.hasOption(LIBSDataGenConstants.CMD_OPT_COMP_VAR_SHORT)) {
+                                double varyBy = Double.parseDouble(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_VARY_BY_SHORT, "0.1"));
+                                double maxDelta = Double.parseDouble(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MAX_DELTA_SHORT, "0.5"));
+                                int variationMode = Integer.parseInt(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_VAR_MODE_SHORT, String.valueOf(LIBSDataGenConstants.STAT_VAR_MODE_GAUSSIAN_DIST)));
+                                int numSamples = Integer.parseInt(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_NUM_VARS_SHORT, "50"));
+                                String effectiveOverviewGuidForVariations = seriesOverviewGuid;
+
+                                if (variationMode == LIBSDataGenConstants.STAT_VAR_MODE_DIRICHLET_DIST) {
+                                    if (effectiveOverviewGuidForVariations == null || effectiveOverviewGuidForVariations.isEmpty()) {
+                                        logger.warning("Dirichlet sampling selected for material " + individualGuid + " in series " + seriesKey +
+                                                       ", but a valid series overview GUID is missing for this series. Skipping variations for this material.");
+                                        continue;
+                                    }
+                                    logger.info("Using series overview GUID " + effectiveOverviewGuidForVariations + " for Dirichlet sampling of material " + individualGuid);
+                                }
+
+                                logger.info("Generating " + numSamples + " compositional variations for " + individualGuid + "...");
+                                ArrayList<ArrayList<Element>> compositions = libsDataService.generateCompositionalVariations(
+                                    baseElements, varyBy, maxDelta, variationMode, numSamples, effectiveOverviewGuidForVariations
+                                );
+
+                                if (compositions == null || compositions.isEmpty()) {
+                                    logger.warning("No compositions generated from variations for material GUID: " + individualGuid + ". Nothing to write to dataset.");
+                                    continue;
+                                }
+
+                                logger.info("Generating dataset for " + compositions.size() + " varied compositions of " + individualGuid + "...");
+                                libsDataService.generateDataset(compositions, minWavelength, maxWavelength, csvDirPath, appendMode, forceFetch);
+                            } else {
+                                logger.info("Fetching base LIBS data for material: " + individualGuid + " (no variations requested).");
+                                libsDataService.fetchLIBSData(baseElements, minWavelength, maxWavelength, csvDirPath, appendMode, forceFetch);
+                            }
+                        } // End loop over individualMaterialGuids
+                    } // End loop over processedSeriesList
+                } else if (cmd.hasOption(LIBSDataGenConstants.CMD_OPT_COMPOSITION_SHORT)) {
+                    // This is the existing -c option logic, ensure matwebService is available if it uses it.
+                    MatwebDataService matwebService = MatwebDataService.getInstance(); // Ensure it's available for -c path too
+                    logger.info("Processing with -c (composition) option.");
                     String compositionInput = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_COMPOSITION_SHORT);
 
-                    // Check if input is a matweb datasheet GUID
+                    // Check if input is a MatWeb datasheet GUID or a composition string
                     Pattern pattern = Pattern.compile(LIBSDataGenConstants.MATWEB_GUID_REGEX);
-                    String[] composition;
-                    if (!pattern.matcher(compositionInput).matches()) {
-                        composition = compositionInput.split(",");
-                    } else {
-                        composition = new MatwebDataService().getMaterialComposition(compositionInput);
+                    String[] compositionArray;
+                    if (compositionInput == null || compositionInput.trim().isEmpty()) {
+                        logger.severe("Composition input is null or empty. Aborting.");
+                        return;
                     }
-                    // Parse the input composition string into an array list of Element objects.
-                    ArrayList<Element> elements = libsDataService.generateElementsList(composition);
-                    logger.info("Elements: " + new CommonUtils().buildCompositionString(elements));
 
-                    String minWavelength = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MIN_WAVELENGTH_SHORT,
-                            "200");
-                    String maxWavelength = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MAX_WAVELENGTH_SHORT,
-                            "800");
-                    String csvDirPath = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_OUTPUT_PATH_SHORT, CommonUtils.DATA_PATH);
-                    logger.info("Processed input data");
+                    if (!pattern.matcher(compositionInput).matches()) {
+                        compositionArray = compositionInput.split(",");
+                    } else {
+                        compositionArray = new MatwebDataService().getMaterialComposition(compositionInput);
+                    }
+
+                    if (compositionArray == null || compositionArray.length == 0) {
+                        logger.severe("Failed to parse composition or retrieve from Matweb. Aborting.");
+                        return;
+                    }
+
+                    ArrayList<Element> elements = libsDataService.generateElementsList(compositionArray);
+                    if (elements == null || elements.isEmpty()) {
+                        logger.severe("Generated elements list is null or empty. Aborting.");
+                        return;
+                    }
+                    logger.info("Elements: " + commonUtils.buildCompositionString(elements));
+                    logger.info("Processed input data for -c option.");
 
                     if (cmd.hasOption(LIBSDataGenConstants.CMD_OPT_COMP_VAR_SHORT)) {
                         double varyBy = Double.parseDouble(
@@ -60,37 +302,41 @@ public class LIBSDataController {
                         double maxDelta = Double.parseDouble(
                                 cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MAX_DELTA_SHORT, "0.5")
                         );
-                        boolean appendMode = !cmd.hasOption(LIBSDataGenConstants.CMD_OPT_NO_APPEND_MODE_SHORT);
-                        boolean forceFetch = cmd.hasOption(LIBSDataGenConstants.CMD_OPT_FORCE_FETCH_SHORT);
 
                         int variationMode = Integer.parseInt(cmd.getOptionValue(
                                 LIBSDataGenConstants.CMD_OPT_VAR_MODE_SHORT,
                                 String.valueOf(LIBSDataGenConstants.STAT_VAR_MODE_GAUSSIAN_DIST)
                         ));
-                        String overGuid = "";
-                        if (variationMode == 2) {
-                            // require an overview GUID for dirichlet sampling
+                        String overGuid = ""; // For -c, this is different from the series overviewGuid
+                        if (variationMode == LIBSDataGenConstants.STAT_VAR_MODE_DIRICHLET_DIST) {
                             if (!cmd.hasOption(LIBSDataGenConstants.CMD_OPT_OVERVIEW_GUID_SHORT)) {
-                                logger.info("Overview GUID not present for Dirichlet sampling of compositional variations. Aborting!");
-                                System.out.println("Overview GUID not present. Please try again by entering input for the -og flag.");
+                                logger.severe("Overview GUID (-og) not present for Dirichlet sampling with -c option. Aborting!");
+                                System.err.println("Error: Overview GUID (-og) must be provided when using variation mode 2 (Dirichlet) with the -c option.");
                                 return;
                             }
                             overGuid = cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_OVERVIEW_GUID_SHORT);
                         }
                         int numSamples = Integer.parseInt(
                                 cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_NUM_VARS_SHORT, "50"));
+
                         ArrayList<ArrayList<Element>> compositions = libsDataService.generateCompositionalVariations(
                                 elements, varyBy, maxDelta, variationMode, numSamples, overGuid);
 
-                        libsDataService.generateDataset(compositions, minWavelength, maxWavelength, csvDirPath,
-                                appendMode, forceFetch);
+                        if (compositions != null && !compositions.isEmpty()) {
+                            libsDataService.generateDataset(compositions, minWavelength, maxWavelength, csvDirPath,
+                                    appendMode, forceFetch);
+                            logger.info("Successfully generated dataset for composition: " + compositionInput);
+                        } else {
+                             logger.warning("No compositions generated for input: " + compositionInput);
+                        }
 
                     } else {
+                        // This is the original non-variation path for -c
                         libsDataService.fetchLIBSData(elements, minWavelength, maxWavelength, csvDirPath);
+                         logger.info("Successfully fetched LIBS data for composition: " + compositionInput);
                     }
-
                 }
-
+                // Note: The case where neither -s nor -c is provided is handled by CommonUtils.getTerminalArgHandler
             }
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Exception occurred!", e);

--- a/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataGenConstants.java
+++ b/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataGenConstants.java
@@ -65,6 +65,12 @@ public class LIBSDataGenConstants {
     public static final String CMD_OPT_OVERVIEW_GUID_DESC = "Matweb GUID for the series overview datasheet. " +
             "Required for Dirichlet sampling mode (mode 2) to get series average compositions.";
 
+    public static final String CMD_OPT_SERIES_SHORT = "s";
+    public static final String CMD_OPT_SERIES_LONG = "series";
+    public static final String CMD_OPT_SERIES_DESC = "Specify a steel series key, a comma-separated list of series keys (e.g., 'key1,key2'), or no argument to process all series from the properties file.";
+
+    public static final String STEEL_SERIES_CATALOG_PATH = "src/main/resources/steel_series_catalog.properties";
+
     /**
      * #### NIST LIBS Constants ####
      */


### PR DESCRIPTION
Introduces a new command-line option `-s` (`--series`) to enable processing of steel series from a properties file. The new logic iterates through each individual material GUID within a series entry in the properties file, processing it similarly to how a single GUID is handled via the `-c` option.

Key changes:

1. **CLI Updates (`CommonUtils.java`, `LIBSDataGenConstants.java`):**
    - Added `-s, --series` option. This option can take an optional argument: - If a series key (from `steel_series_catalog.properties`) is provided, that specific series is processed. - If no argument is provided to `-s`, all series in the properties file are processed.
    - The `-c, --composition` option is now optional.
    - The application now requires that either `-c` or `-s` be specified, but not both.
    - Constants for the new CLI option are added to `LIBSDataGenConstants.java`.

2.  **Revised GUID Extraction (`LIBSDataController.java`):**
    -   A new `SeriesData` inner class now stores the series key, a list
        of its validated individual material GUIDs, and its validated
        overview GUID.
    -   The `parseSeriesEntry` helper method populates `SeriesData`
        objects from the `steel_series_catalog.properties` file,
        validating all GUIDs.

3.  **Per-Material Processing Loop (`LIBSDataController.java`):**
    -   The controller now iterates through each selected series and then
        through each individual material GUID within that series.
    -   For each individual material GUID:
        a.  Its specific composition is fetched from MatWeb using
            `MatwebDataService.getMaterialComposition()`.
        b.  An `ArrayList<Element>` (`baseElements`) is generated.
        c.  If the `-v` (variations) flag is present:
            -   `LIBSDataService.generateCompositionalVariations()` is
                called using these `baseElements`. The overview GUID
                associated with the current series is passed for use by
                variation algorithms (e.g., Dirichlet sampling).
            -   If Dirichlet mode is selected and the series' overview
                GUID is missing, variations for that material are skipped.
            -   `LIBSDataService.generateDataset()` is called for the
                resulting compositions.
        d.  If the `-v` flag is not present:
            -   `LIBSDataService.fetchLIBSData()` is called for the
                `baseElements` to get data for the base material.
    -   This replaces the previous series processing logic that primarily
        focused on the overview GUID for variations.

3.  **Enhanced Logging:**
    -   Logging throughout the series and material processing loops has
        been updated to provide clear traceability of operations and
        errors for each individual material.

4.  **Error Handling:**
    -   Improved error handling for failures during composition
        fetching, element generation, and cases where necessary
        overview GUIDs for Dirichlet sampling are missing.

This major refactoring ensures that the `-s` option correctly processes each material listed in a series, providing a more comprehensive data generation capability for entire steel families.