### PR TITLE
[fix] Fixed issue with num of input samples generated

### DIFF
--- a/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataController.java
+++ b/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataController.java
@@ -97,7 +97,7 @@ public class LIBSDataController {
                             cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MAX_DELTA_SHORT, "0.05")
                     );
                     int numSamples = Integer.parseInt(
-                            cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_NUM_VARS_SHORT, "50"));
+                            cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_NUM_VARS_SHORT, "20"));
 
                     List<List<Element>> compositions = CompositionalVariations.getInstance()
                             .generateCompositionalVariations(

--- a/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataGenConstants.java
+++ b/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataGenConstants.java
@@ -59,7 +59,7 @@ public class LIBSDataGenConstants {
     public static final String CMD_OPT_VAR_MODE_SHORT = "vm";
     public static final String CMD_OPT_VAR_MODE_LONG = "variation-mode";
     public static final String CMD_OPT_VAR_MODE_DESC = "Chooses the variation mode: " +
-            "0 - uniform dist, 1 - Gaussian sampling (default), 2 - Dirichlet sampling";
+            "1 - Dirichlet sampling (default), 2 - Gaussian sampling";
     public static final String CMD_OPT_OVERVIEW_GUID_SHORT = "og";
     public static final String CMD_OPT_OVERVIEW_GUID_LONG = "overview-guid";
     public static final String CMD_OPT_OVERVIEW_GUID_DESC = "Matweb GUID for the series overview datasheet. " +
@@ -121,8 +121,8 @@ public class LIBSDataGenConstants {
     public static final String INPUT_COMPOSITION_STRING_REGEX = "^([A-Za-z]{1,2}-((100(\\.0{1,5})?|[0-9]{1,2}(\\.\\d{1,5})?)%?|[#]))(?:,([A-Za-z]{1,2}-((100(\\.0{1,5})?|[0-9]{1,2}(\\.\\d{1,5})?)%?|[#])))*$";
     public static final String DIRECT_ENTRY = "Direct-entry"; // Used to mark MatGUID series list entry via -c option
     public static final int STAT_VAR_MODE_UNIFORM_DIST = 0; // Uniform distribution mode (longest and unnecessary)
-    public static final int STAT_VAR_MODE_GAUSSIAN_DIST = 1; // Gaussian sampling mode
-    public static final int STAT_VAR_MODE_DIRICHLET_DIST = 2; // Dirichlet sampling mode
+    public static final int STAT_VAR_MODE_DIRICHLET_DIST = 1; // Dirichlet sampling mode
+    public static final int STAT_VAR_MODE_GAUSSIAN_DIST = 2; // Gaussian sampling mode
 
     // Default concentration parameter for Dirichlet distribution. Higher = less variance.
     public static final double DIRICHLET_BASE_CONCENTRATION = 100.0;

--- a/src/main/java/com/medals/libsdatagenerator/service/CompositionalVariations.java
+++ b/src/main/java/com/medals/libsdatagenerator/service/CompositionalVariations.java
@@ -74,16 +74,17 @@ public class CompositionalVariations {
         // System.out.println("\nGenerating different combinations for the input composition (refer log for list)...");
         logger.info("\nGenerating different combinations for the input composition (refer log for list)...");
 
+        int numVariationsToGenerate = Math.max(0, samples - 1);
 
         if (variationMode == LIBSDataGenConstants.STAT_VAR_MODE_GAUSSIAN_DIST) {
             Map<String, Object> metadata = new HashMap<>();
             metadata.put("maxDelta", maxDelta);
-            GaussianSampler.getInstance().sample(effectiveComposition, samples, compositions, metadata);
+            GaussianSampler.getInstance().sample(effectiveComposition, numVariationsToGenerate, compositions, metadata);
 
         } else if (variationMode == LIBSDataGenConstants.STAT_VAR_MODE_DIRICHLET_DIST) {
             Map<String, Object> metadata = new HashMap<>();
             metadata.put("overviewGuid", overviewGuid);
-            DirichletSampler.getInstance().sample(effectiveComposition, samples, compositions, metadata);
+            DirichletSampler.getInstance().sample(effectiveComposition, numVariationsToGenerate, compositions, metadata);
 
         } else { // For uniform distribution
             // Start backtracking with an empty "current combo" and a running sum of 0

--- a/src/test/java/com/medals/libsdatagenerator/service/LIBSDataServiceTest.java
+++ b/src/test/java/com/medals/libsdatagenerator/service/LIBSDataServiceTest.java
@@ -63,8 +63,8 @@ class LIBSDataServiceTest {
             LIBSDataGenConstants.STAT_VAR_MODE_GAUSSIAN_DIST, 10, null
         );
 
-        // Expected size is samples + 1 (original)
-        assertEquals(11, compositions.size(), "Should generate original + requested number of samples.");
+        // Expected size is original + samples
+        assertEquals(10, compositions.size(), "Should generate original + requested number of samples.");
 
         boolean foundDifferent = false;
         for (int i = 1; i < compositions.size(); i++) { // Start from 1 to skip original


### PR DESCRIPTION
- Fixed issue with num of input samples generated for original composition. 
- Changed default -n from 50 to 20. 
- Updated -vm description to reflect Dirichlet sampling as default.

Fixes final issue in #24 .