### PR TITLE
[fix] Fixed compvariation bug due to incorrect handling of remainder logic

### DIFF
--- a/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataGenConstants.java
+++ b/src/main/java/com/medals/libsdatagenerator/controller/LIBSDataGenConstants.java
@@ -114,10 +114,10 @@ public class LIBSDataGenConstants {
     public static final String CMD_OPT_FORCE_FETCH_LONG = "force-fetch";
     public static final String CMD_OPT_FORCE_FETCH_DESC = "Will force re-downloading of individual spectrum data " +
             "for every composition even if data is available locally in the /data directory.";
-    public static final String CMD_OPT_SCALE_COATING_SHORT = "sc";
-    public static final String CMD_OPT_SCALE_COATING_LONG = "scale-coating";
+    public static final String CMD_OPT_SCALE_COATING_SHORT = "dsc";
+    public static final String CMD_OPT_SCALE_COATING_LONG = "dont-scale-coating";
     public static final String CMD_OPT_SCALE_COATING_DESC = "Will scale down all other elements in the composition rather " +
-            "than subtracting the coating element percentage from the dominant element's percentage. Disabled by default.";
+            "than subtracting the coating element percentage from the dominant element's percentage by default. Include flag to disable.";
     @Deprecated
     public static final String CMD_OPT_VARY_BY_SHORT = "vb";
     @Deprecated

--- a/src/main/java/com/medals/libsdatagenerator/model/UserInputConfig.java
+++ b/src/main/java/com/medals/libsdatagenerator/model/UserInputConfig.java
@@ -69,7 +69,7 @@ public class UserInputConfig {
         this.variationMode = VariationMode.fromOption(Integer.parseInt(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_VAR_MODE_SHORT, "1")));
         this.classLabelTypeExplicitlySet = cmd.hasOption(LIBSDataGenConstants.CMD_OPT_CLASS_TYPE_SHORT);
         this.classLabelType = ClassLabelType.fromOption(Integer.parseInt(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_CLASS_TYPE_SHORT, "1")));
-        this.scaleCoating = cmd.hasOption(LIBSDataGenConstants.CMD_OPT_SCALE_COATING_SHORT);
+        this.scaleCoating = !cmd.hasOption(LIBSDataGenConstants.CMD_OPT_SCALE_COATING_SHORT);
         this.varyBy = Double.parseDouble(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_VARY_BY_SHORT, "0.1"));
         this.maxDelta = Double.parseDouble(cmd.getOptionValue(LIBSDataGenConstants.CMD_OPT_MAX_DELTA_SHORT, "0.05"));
 

--- a/src/main/java/com/medals/libsdatagenerator/service/CompositionalVariations.java
+++ b/src/main/java/com/medals/libsdatagenerator/service/CompositionalVariations.java
@@ -20,7 +20,7 @@ public class CompositionalVariations {
     private final Logger logger = Logger.getLogger(CompositionalVariations.class.getName());
     private static CompositionalVariations instance = null;
     private final CommonUtils commonUtils;
-    private static final double POST_NORM_CHECK_DELTA = 0.0001;
+    public static final double POST_NORM_CHECK_DELTA = 0.0001;
     private static final double FINAL_SUM_TOLERANCE = 0.1;
 
     public CompositionalVariations() {

--- a/src/main/java/com/medals/libsdatagenerator/service/MatwebDataService.java
+++ b/src/main/java/com/medals/libsdatagenerator/service/MatwebDataService.java
@@ -350,9 +350,9 @@ public class MatwebDataService {
 
         // If no remainder element was found, automatically mark the element with the highest percentage
         if (!hasRemainderElement && maxIndex >= 0) {
-            String[] parts = parsedElementString[maxIndex].split("-");
-            parsedElementString[maxIndex] = parts[0] + "-#";
-            logger.info("Automatically marked element " + parts[0] + " as remainder (highest percentage: " + maxPercentage + "%)");
+            parsedElementString[maxIndex] += "-#";
+            logger.info("Automatically marked element " + parsedElementString[maxIndex].split("-")[0]
+                    + " as remainder (highest percentage: " + maxPercentage + "%)");
         }
 
         return parsedElementString;

--- a/src/test/java/com/medals/libsdatagenerator/service/MatwebDataServiceTest.java
+++ b/src/test/java/com/medals/libsdatagenerator/service/MatwebDataServiceTest.java
@@ -55,7 +55,7 @@ class MatwebDataServiceTest {
         
         assertNotNull(result);
         assertEquals(3, result.length);
-        assertEquals("Cu-#", result[0]); // Cu has highest percentage, should be marked as remainder
+        assertEquals("Cu-85.0:85.0-#", result[0]); // Cu has highest percentage, should be marked as remainder
         assertEquals("Zn-10.0:10.0", result[1]);
         assertEquals("Pb-0.5:0.5", result[2]);
     }
@@ -72,7 +72,7 @@ class MatwebDataServiceTest {
         assertNotNull(result);
         assertEquals(3, result.length);
         // Cu has highest average percentage (88.85%), should be marked as remainder
-        assertEquals("Cu-#", result[0]);
+        assertEquals("Cu-78.8:98.9-#", result[0]);
         assertEquals("Zn-0.250:18.0", result[1]);
         assertEquals("Pb-0.05:0.40", result[2]);
     }
@@ -103,7 +103,7 @@ class MatwebDataServiceTest {
         
         assertNotNull(result);
         assertEquals(3, result.length);
-        assertEquals("Fe-#", result[0]); // Fe has highest percentage, should be marked as remainder
+        assertEquals("Fe-98.0:98.0-#", result[0]); // Fe has highest percentage, should be marked as remainder
         assertEquals("C-0:0.5", result[1]); // <= format
         assertEquals("Mn-0.5:1.5", result[2]); // Range format
     }


### PR DESCRIPTION
This pull request updates how the remainder (dominant) element is handled in composition parsing and improves the clarity and consistency of command line options for scaling coating elements. It also refines the logic for generating element lists and updates related tests to match the new format.

**Command Line Options and Configuration Changes**
* Renamed the command line option for scaling coating elements from `scale-coating` (`sc`) to `dont-scale-coating` (`dsc`), and inverted its logic: the flag now disables scaling rather than enabling it. The description was updated for clarity.
* Updated `UserInputConfig` so that the `scaleCoating` property is set to `false` when the new `dont-scale-coating` flag is present, instead of `true` as before.

**Element Composition Parsing and Generation**
* Refactored `generateElementsList` to more robustly handle remainder elements marked with `#`, ensuring correct assignment of percentages and ranges for dominant elements. This logic now also uses `POST_NORM_CHECK_DELTA` for tolerance and supports both single values and ranges. [[1]](diffhunk://#diff-4795c3750d2d77b1c89ede8a97cc03e3c1ebdba7d380fc1912db47bc06138b68L188-R254) [[2]](diffhunk://#diff-48463ba05da439e06843235a27e890d3c17ba72a02dd7c42c77701fc68486021L23-R23)
* Improved the automatic detection and marking of the remainder element in `parseCompositionData` so that the dominant element retains its percentage/range and is marked with `-#` for clarity.

**Testing Updates**
* Updated tests in `MatwebDataServiceTest` to expect the new format for remainder elements (e.g., `"Cu-85.0:85.0-#"` instead of `"Cu-#"`), reflecting the changes in parsing logic and output. [[1]](diffhunk://#diff-90229a3ae0da34bc83666a90454dbd7c4a1e1345940cf21ec901629693110d3eL58-R58) [[2]](diffhunk://#diff-90229a3ae0da34bc83666a90454dbd7c4a1e1345940cf21ec901629693110d3eL75-R75) [[3]](diffhunk://#diff-90229a3ae0da34bc83666a90454dbd7c4a1e1345940cf21ec901629693110d3eL106-R106)…element logic when parsing from matweb - issue #72. Also flipped scale coating logic.